### PR TITLE
Batch UI window title and size adjustment, layout on model tab.

### DIFF
--- a/repast.simphony.distributed.batch.ui/src/repast/simphony/batch/gui/Main.java
+++ b/repast.simphony.distributed.batch.ui/src/repast/simphony/batch/gui/Main.java
@@ -4,6 +4,7 @@
 package repast.simphony.batch.gui;
 
 import java.awt.BorderLayout;
+import java.awt.Dimension;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -66,7 +67,9 @@ public class Main {
     else
       frame.add(new MainPanel(), BorderLayout.CENTER);
     frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
-    frame.setSize(650, 550);
+    frame.setSize(650, 650);
+    frame.setMinimumSize(new Dimension(600, 430));
+    frame.setTitle("Repast Simphony Batch");
     frame.setLocationRelativeTo(null);
     frame.setVisible(true);
   }

--- a/repast.simphony.distributed.batch.ui/src/repast/simphony/batch/gui/ModelPanel.java
+++ b/repast.simphony.distributed.batch.ui/src/repast/simphony/batch/gui/ModelPanel.java
@@ -73,7 +73,7 @@ public class ModelPanel extends JPanel implements BatchRunPanel {
     formBuilder.nextLine();
     formBuilder.append(new JLabel("Optional Output File Patterns:"), 4);
     formBuilder.nextLine();
-    formBuilder.defaultRowSpec(RowSpec.decode("fill:pref"));
+    formBuilder.defaultRowSpec(RowSpec.decode("fill:pref:grow"));
     
     formBuilder.append(createPatternPanel(), 5);
     formBuilder.defaultRowSpec(FormSpecs.PREF_ROWSPEC);
@@ -91,8 +91,11 @@ public class ModelPanel extends JPanel implements BatchRunPanel {
     
     formBuilder.append("Poll Frequency (minutes):");
     formBuilder.append(pollSpn, 1);
-    
-    add(formBuilder.getPanel(), BorderLayout.CENTER);
+
+    JScrollPane sp = new JScrollPane(formBuilder.getPanel());
+    sp.getVerticalScrollBar().setUnitIncrement(8);
+    sp.getViewport().setOpaque(false);
+    add(sp, BorderLayout.CENTER);
     bindComponents(pModel);
     initListeners();
   }


### PR DESCRIPTION
Minor adjustments to the batch UI. 

- Add title to the window.
- Small adjustment to the initial size, to fit all content of the Model tab.
- Specify a minimum size for the window. This also avoid scrolling on other tabs than Model.
- On the Model tab, allow the Patterns table to grow vertically. Also scroll the entire contents, if not fitting in window.
